### PR TITLE
Changing http to https in app.css to prevent mixed content warning in Firefox

### DIFF
--- a/site/assets/stylesheets/app.css
+++ b/site/assets/stylesheets/app.css
@@ -17,7 +17,7 @@
 /* -----------------------------------------
    Shared Styles
 ----------------------------------------- */
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:400,300);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans:400,300);
 
 html { background: #FFF; }
 


### PR DESCRIPTION
Changing http to https in app.css to prevent mixed content warning in Firefox
